### PR TITLE
Display current game score on new game start

### DIFF
--- a/ask.js
+++ b/ask.js
@@ -48,6 +48,10 @@ function start() {
 
   gameoff.hidden = true;
   gameon.hidden = false;
+
+  // Display the score of a new game
+  score.innerText = Game.score;
+
   ask();
 }
 


### PR DESCRIPTION
# Issue
When after finishing a game the new one is started until the first answer the score for already finished game is shown, which is pretty awkward (answered no question, having 5 points of ten).  For more details see #2 

# Solution
What this commit does is simply refreshes score display so users could see the score of
current game.

Closes #2 